### PR TITLE
CRUD operations for Sequence objects + add/remove page elements

### DIFF
--- a/pages/api/elements.py
+++ b/pages/api/elements.py
@@ -38,7 +38,8 @@ from ..mixins import AccountMixin, PageElementMixin, TrailMixin
 from ..models import (PageElement, RelationShip, build_content_tree,
     flatten_content_tree, Sequence, EnumeratedElements)
 from ..serializers import (NodeElementSerializer, PageElementSerializer,
-    PageElementTagSerializer, SequenceSerializer, UpdateEnumeratedElementSerializer)
+    PageElementTagSerializer, SequenceSerializer, UpdateEnumeratedElementSerializer,
+    UpdateSequenceSerializer)
 from ..utils import validate_title
 
 LOGGER = logging.getLogger(__name__)
@@ -712,13 +713,11 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
     .. code-block:: json
 
         {
-            "id": 3,
             "created_at": "2023-10-14T05:23:42.452684Z",
-            "slug": "NewSequence",
+            "slug": "newsequence",
             "title": "NewSequence",
             "account": admin,
             "extra": null,
-            "elements": []
         }
 
     - **Retrieve a Sequence**
@@ -736,7 +735,7 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
             "created_at": "2023-10-13T21:47:44.922545Z",
             "slug": "sequence1",
             "title": "Sequence 1",
-            "account": 3,
+            "account": "admin",
             "extra": "",
             "elements": [
                 {
@@ -755,11 +754,10 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
         Content-Type: application/json
 
         {
-            "slug": "updatedsequence"
+            "slug": "updatedsequence",
             "title": "UpdatedSequence",
             "account": alice,
             "extra": "",
-
         }
 
     responds
@@ -767,13 +765,11 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
     .. code-block:: json
 
         {
-            "id": 3,
-            "created_at": "2023-10-14T05:23:42.452684Z",
-            "slug": "updatedsequence",
+            "created_at": "2023-10-15T04:16:24.808028Z",
+            "slug": "updatedsequence"
             "title": "UpdatedSequence",
             "account": alice,
             "extra": "",
-            "elements": []
         }
 
     - **Add Element to Sequence**
@@ -821,8 +817,10 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
     queryset = Sequence.objects.all().order_by('pk')
 
     def get_serializer_class(self):
-        if self.action in ['add_element', 'remove_element']:
+        if self.action.lower() in ['add_element', 'remove_element']:
             return UpdateEnumeratedElementSerializer
+        if self.action.lower() in ['create', 'update']:
+            return UpdateSequenceSerializer
         return super().get_serializer_class()
 
     def destroy(self, request, *args, **kwargs):

--- a/pages/api/elements.py
+++ b/pages/api/elements.py
@@ -27,7 +27,8 @@ from django.core.exceptions import ValidationError
 from django.db import transaction, IntegrityError
 from django.db.models import Max, Q
 from django.http import Http404
-from rest_framework import generics, response as api_response, viewsets
+from rest_framework import (generics, response as api_response,
+                            viewsets, status)
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.decorators import action
@@ -38,8 +39,7 @@ from ..mixins import AccountMixin, PageElementMixin, TrailMixin
 from ..models import (PageElement, RelationShip, build_content_tree,
     flatten_content_tree, Sequence, EnumeratedElements)
 from ..serializers import (NodeElementSerializer, PageElementSerializer,
-    PageElementTagSerializer, SequenceSerializer, UpdateEnumeratedElementSerializer,
-    UpdateSequenceSerializer)
+    PageElementTagSerializer, SequenceSerializer, EnumeratedElementSerializer)
 from ..utils import validate_title
 
 LOGGER = logging.getLogger(__name__)
@@ -661,177 +661,195 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
     Also allows adding/removing page elements from sequences.
 
      **Tags**: sequences
-
-    **Examples**
-    - **List Sequences**
-
-    .. code-block:: http
-
-        GET /api/sequences/ HTTP/1.1
-
-    responds
-
-    .. code-block:: json
-
-    "count": 1,
-    "next": null,
-    "previous": null,
-    "results": [
-        {
-            "id": 1,
-            "created_at": "2023-10-13T21:47:44.922545Z",
-            "slug": "Sequence1",
-            "title": "Sequence 1",
-            "account": 3,
-            "extra": "",
-            "elements": [
-                {
-                    "page_element": "metal",
-                    "rank": 8,
-                    "min_viewing_duration": "00:00:00"
-                }
-            ]
-        }
-    ]
-    - **Create a Sequence**
-
-    .. code-block:: http
-
-        POST /api/sequences/ HTTP/1.1
-        Content-Type: application/json
-
-        {
-            "slug": "newsequence"
-            "title": "NewSequence",
-            "account": admin,
-            "extra": null,
-
-        }
-
-    responds
-
-    .. code-block:: json
-
-        {
-            "created_at": "2023-10-14T05:23:42.452684Z",
-            "slug": "newsequence",
-            "title": "NewSequence",
-            "account": admin,
-            "extra": null,
-        }
-
-    - **Retrieve a Sequence**
-
-    .. code-block:: http
-
-        GET /api/sequences/1/ HTTP/1.1
-
-    responds
-
-    .. code-block:: json
-
-        {
-            "id": 1,
-            "created_at": "2023-10-13T21:47:44.922545Z",
-            "slug": "sequence1",
-            "title": "Sequence 1",
-            "account": "admin",
-            "extra": "",
-            "elements": [
-                {
-                    "page_element": "metal",
-                    "rank": 8,
-                    "min_viewing_duration": "00:00:00"
-                }
-            ]
-        }
-
-    - **Update a Sequence**
-
-    .. code-block:: http
-
-        PUT /api/sequences/1/ HTTP/1.1
-        Content-Type: application/json
-
-        {
-            "slug": "updatedsequence",
-            "title": "UpdatedSequence",
-            "account": alice,
-            "extra": "",
-        }
-
-    responds
-
-    .. code-block:: json
-
-        {
-            "created_at": "2023-10-15T04:16:24.808028Z",
-            "slug": "updatedsequence"
-            "title": "UpdatedSequence",
-            "account": alice,
-            "extra": "",
-        }
-
-    - **Add Element to Sequence**
-
-    .. code-block:: http
-
-        POST /api/sequences/1/add_element/ HTTP/1.1
-        Content-Type: application/json
-
-        {
-            "page_element": production,
-            "rank": 1
-        }
-
-    responds
-
-    .. code-block:: json
-
-        {
-            "detail": "element added"
-        }
-
-    - **Remove Element from Sequence**
-
-    .. code-block:: http
-
-        POST /api/sequences/1/remove_element/ HTTP/1.1
-        Content-Type: application/json
-
-        {
-            "page_element": production,
-            "rank": 1
-        }
-
-    responds
-
-    .. code-block:: json
-
-        {
-            "detail": "element removed"
-        }
-
     """
     serializer_class = SequenceSerializer
-    queryset = Sequence.objects.all().order_by('pk')
+    http_method_names = ['get', 'post', 'head', 'patch', 'delete', 'options']
+    queryset = Sequence.objects.all().order_by('slug')
+    lookup_field = 'slug'
 
     def get_serializer_class(self):
-        if self.action.lower() in ['add_element', 'remove_element']:
-            return UpdateEnumeratedElementSerializer
-        if self.action.lower() in ['create', 'update']:
-            return UpdateSequenceSerializer
+        if self.action:
+            if self.action.lower() in ['add_element', 'remove_element']:
+                return EnumeratedElementSerializer
+            if self.action.lower() in ['create', 'update']:
+                return SequenceSerializer
         return super().get_serializer_class()
 
+    def list(self, request, *args, **kwargs):
+        """
+        - **List Sequences**
+
+        .. code-block:: http
+
+            GET /api/sequences HTTP/1.1
+
+        responds
+
+        .. code-block:: json
+
+        "count": 1,
+        "next": null,
+        "previous": null,
+        "results": [
+            {
+                "created_at": "2023-10-13T21:47:44.922545Z",
+                "slug": "Sequence1",
+                "title": "Sequence 1",
+                "account": "admin",
+                "extra": "",
+                "elements": [
+                    {
+                        "page_element": "metal",
+                        "rank": 8,
+                        "min_viewing_duration": "00:00:00"
+                    }
+                ]
+            }
+        ]
+
+        """
+        return super(SequenceAPIView, self).list(
+            request, *args, **kwargs)
+
+    def retrieve(self, request, *args, **kwargs):
+        """
+            - **Retrieve a Sequence**
+
+        .. code-block:: http
+
+            GET /api/sequences/sequence1 HTTP/1.1
+
+        responds
+
+        .. code-block:: json
+
+            {
+                "created_at": "2023-10-13T21:47:44.922545Z",
+                "slug": "sequence1",
+                "title": "Sequence 1",
+                "account": "admin",
+                "extra": "",
+                "elements": [
+                    {
+                        "page_element": "metal",
+                        "rank": 8,
+                        "min_viewing_duration": "00:00:00"
+                    }
+                ]
+            }
+
+        """
+        return super(SequenceAPIView, self).retrieve(
+            request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        """
+        - **Update a Sequence**
+
+        .. code-block:: http
+
+            PATCH /api/sequences/updatedsequence HTTP/1.1
+            Content-Type: application/json
+
+            {
+                "slug": "updatedsequence",
+                "title": "UpdatedSequence",
+                "account": alice,
+                "extra": "",
+            }
+
+        responds
+
+        .. code-block:: json
+
+            {
+                "created_at": "2023-10-15T04:16:24.808028Z",
+                "slug": "updatedsequence"
+                "title": "UpdatedSequence",
+                "account": alice,
+                "extra": "",
+            }
+        """
+        return super(SequenceAPIView, self).partial_update(
+            request, *args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        """
+        - **Create a Sequence**
+
+        .. code-block:: http
+
+            POST /api/sequences HTTP/1.1
+            Content-Type: application/json
+
+            {
+                "slug": "newsequence"
+                "title": "NewSequence",
+                "account": admin,
+                "extra": null,
+
+            }
+
+        responds
+
+        .. code-block:: json
+
+            {
+                "created_at": "2023-10-14T05:23:42.452684Z",
+                "slug": "newsequence",
+                "title": "NewSequence",
+                "account": admin,
+                "extra": null,
+            }
+        """
+        return super(SequenceAPIView, self).create(
+            request, *args, **kwargs)
+
     def destroy(self, request, *args, **kwargs):
+        """
+        - **Delete a Sequence**
+
+        .. code-block:: http
+
+            POST /api/sequences/1 HTTP/1.1
+            Content-Type: application/json
+
+        responds
+
+        .. code-block:: json
+
+            {
+            }
+        """
         instance = self.get_object()
         self.perform_destroy(instance)
-        return api_response.Response({'detail': 'sequence deleted'}, status=200)
+        return api_response.Response({'detail': 'sequence deleted'},
+                                     status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=['post'])
-    def add_element(self, request, pk=None):
+    def add_element(self, request, slug=None):
         """
+        - **Add Element to Sequence**
+
         Adds an element to a sequence. Creates a new `EnumeratedElements` instance.
+
+        .. code-block:: http
+
+            POST /api/sequences/1/add_element HTTP/1.1
+            Content-Type: application/json
+
+            {
+                "page_element": production,
+                "rank": 1
+            }
+
+        responds
+
+        .. code-block:: json
+
+            {
+                "detail": "element added"
+            }
         """
         #pylint:disable=unused-argument
         sequence = self.get_object()
@@ -839,18 +857,41 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
         if serializer.is_valid():
             try:
                 serializer.save(sequence=sequence)
-                return api_response.Response({'detail':
-                                                'element added'}, status=200)
+                return api_response.Response({'detail': 'element added'},
+                                             status=status.HTTP_200_OK)
             except IntegrityError:
                 return api_response.Response({'detail':
-                  'An element already exists on this rank for this sequence.'}, status=400)
-        return api_response.Response({'detail': 'invalid parameters'}, status=400)
+                  'An element already exists on this rank for this sequence.'},
+                  status=status.HTTP_400_BAD_REQUEST)
+        return api_response.Response({'detail': 'invalid parameters'},
+                                     status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=True, methods=['post'])
-    def remove_element(self, request, pk=None):
+    def remove_element(self, request, ):
         """
+        - **Remove Element from Sequence**
+
         Removes an element from a sequence. Requires a specified rank and page_element
         to delete the EnumeratedElements instance.
+
+        .. code-block:: http
+
+            POST /api/sequences/1/remove_element HTTP/1.1
+            Content-Type: application/json
+
+            {
+                "page_element": production,
+                "rank": 1
+            }
+
+        responds
+
+        .. code-block:: json
+
+            {
+                "detail": "element removed"
+            }
+
         """
         #pylint:disable=unused-argument
         sequence = self.get_object()
@@ -863,7 +904,10 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
             ).first().delete()
 
             if deleted:
-                return api_response.Response({'detail': 'element removed'}, status=200)
+                return api_response.Response({'detail': 'element removed'},
+                                             status=status.HTTP_200_OK)
             return api_response.Response({'detail': 'element at the specified rank '
-                                                    'not found in sequence'}, status=404)
-        return api_response.Response({'detail': 'invalid parameters'}, status=400)
+                                                    'not found in sequence'},
+                                         status=status.HTTP_404_NOT_FOUND)
+        return api_response.Response({'detail': 'invalid parameters'},
+                                     status=status.HTTP_400_BAD_REQUEST)

--- a/pages/api/elements.py
+++ b/pages/api/elements.py
@@ -24,20 +24,21 @@
 import logging
 
 from django.core.exceptions import ValidationError
-from django.db import transaction
+from django.db import transaction, IntegrityError
 from django.db.models import Max, Q
 from django.http import Http404
-from rest_framework import generics, response as api_response
+from rest_framework import generics, response as api_response, viewsets
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.filters import OrderingFilter, SearchFilter
+from rest_framework.decorators import action
 
 from ..compat import reverse
 from ..helpers import ContentCut, get_extra
 from ..mixins import AccountMixin, PageElementMixin, TrailMixin
 from ..models import (PageElement, RelationShip, build_content_tree,
-    flatten_content_tree)
+    flatten_content_tree, Sequence, EnumeratedElements)
 from ..serializers import (NodeElementSerializer, PageElementSerializer,
-    PageElementTagSerializer)
+    PageElementTagSerializer, SequenceSerializer, UpdateEnumeratedElementSerializer)
 from ..utils import validate_title
 
 LOGGER = logging.getLogger(__name__)
@@ -645,3 +646,226 @@ class PageElementRemoveTags(AccountMixin, PageElementMixin,
                 curr_tags.remove(tag)
         serializer.instance.extra = ','.join(curr_tags)
         serializer.instance.save()
+
+class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancestors
+    """
+    Manages sequences of page elements
+
+    This API endpoint allows for the creation, modification, and deletion
+    of sequences. A sequence is a collection of page elements organized
+    in a specific order. Each page element in a sequence is represented
+    by an enumerated element which holds the position (rank) of the page
+    element in the sequence.
+
+    Also allows adding/removing page elements from sequences.
+
+     **Tags**: sequences
+
+    **Examples**
+    - **List Sequences**
+
+    .. code-block:: http
+
+        GET /api/sequences/ HTTP/1.1
+
+    responds
+
+    .. code-block:: json
+
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "created_at": "2023-10-13T21:47:44.922545Z",
+            "slug": "Sequence1",
+            "title": "Sequence 1",
+            "account": 3,
+            "extra": "",
+            "elements": [
+                {
+                    "page_element": "metal",
+                    "rank": 8,
+                    "min_viewing_duration": "00:00:00"
+                }
+            ]
+        }
+    ]
+    - **Create a Sequence**
+
+    .. code-block:: http
+
+        POST /api/sequences/ HTTP/1.1
+        Content-Type: application/json
+
+        {
+            "slug": "newsequence"
+            "title": "NewSequence",
+            "account": admin,
+            "extra": null,
+
+        }
+
+    responds
+
+    .. code-block:: json
+
+        {
+            "id": 3,
+            "created_at": "2023-10-14T05:23:42.452684Z",
+            "slug": "NewSequence",
+            "title": "NewSequence",
+            "account": admin,
+            "extra": null,
+            "elements": []
+        }
+
+    - **Retrieve a Sequence**
+
+    .. code-block:: http
+
+        GET /api/sequences/1/ HTTP/1.1
+
+    responds
+
+    .. code-block:: json
+
+        {
+            "id": 1,
+            "created_at": "2023-10-13T21:47:44.922545Z",
+            "slug": "sequence1",
+            "title": "Sequence 1",
+            "account": 3,
+            "extra": "",
+            "elements": [
+                {
+                    "page_element": "metal",
+                    "rank": 8,
+                    "min_viewing_duration": "00:00:00"
+                }
+            ]
+        }
+
+    - **Update a Sequence**
+
+    .. code-block:: http
+
+        PUT /api/sequences/1/ HTTP/1.1
+        Content-Type: application/json
+
+        {
+            "slug": "updatedsequence"
+            "title": "UpdatedSequence",
+            "account": alice,
+            "extra": "",
+
+        }
+
+    responds
+
+    .. code-block:: json
+
+        {
+            "id": 3,
+            "created_at": "2023-10-14T05:23:42.452684Z",
+            "slug": "updatedsequence",
+            "title": "UpdatedSequence",
+            "account": alice,
+            "extra": "",
+            "elements": []
+        }
+
+    - **Add Element to Sequence**
+
+    .. code-block:: http
+
+        POST /api/sequences/1/add_element/ HTTP/1.1
+        Content-Type: application/json
+
+        {
+            "page_element": production,
+            "rank": 1
+        }
+
+    responds
+
+    .. code-block:: json
+
+        {
+            "detail": "element added"
+        }
+
+    - **Remove Element from Sequence**
+
+    .. code-block:: http
+
+        POST /api/sequences/1/remove_element/ HTTP/1.1
+        Content-Type: application/json
+
+        {
+            "page_element": production,
+            "rank": 1
+        }
+
+    responds
+
+    .. code-block:: json
+
+        {
+            "detail": "element removed"
+        }
+
+    """
+    serializer_class = SequenceSerializer
+    queryset = Sequence.objects.all().order_by('pk')
+
+    def get_serializer_class(self):
+        if self.action in ['add_element', 'remove_element']:
+            return UpdateEnumeratedElementSerializer
+        return super().get_serializer_class()
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        return api_response.Response({'detail': 'sequence deleted'}, status=200)
+
+    @action(detail=True, methods=['post'])
+    def add_element(self, request, pk=None):
+        """
+        Adds an element to a sequence. Creates a new `EnumeratedElements` instance.
+        """
+        #pylint:disable=unused-argument
+        sequence = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        if serializer.is_valid():
+            try:
+                serializer.save(sequence=sequence)
+                return api_response.Response({'detail':
+                                                'element added'}, status=200)
+            except IntegrityError:
+                return api_response.Response({'detail':
+                  'An element already exists on this rank for this sequence.'}, status=400)
+        return api_response.Response({'detail': 'invalid parameters'}, status=400)
+
+    @action(detail=True, methods=['post'])
+    def remove_element(self, request, pk=None):
+        """
+        Removes an element from a sequence. Requires a specified rank and page_element
+        to delete the EnumeratedElements instance.
+        """
+        #pylint:disable=unused-argument
+        sequence = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        if serializer.is_valid():
+            deleted, _ = EnumeratedElements.objects.filter(
+                sequence=sequence,
+                page_element=serializer.validated_data['page_element'],
+                rank=serializer.validated_data['rank']
+            ).first().delete()
+
+            if deleted:
+                return api_response.Response({'detail': 'element removed'}, status=200)
+            return api_response.Response({'detail': 'element at the specified rank '
+                                                    'not found in sequence'}, status=404)
+        return api_response.Response({'detail': 'invalid parameters'}, status=400)

--- a/pages/models.py
+++ b/pages/models.py
@@ -394,7 +394,8 @@ class EnumeratedElements(models.Model):
     """
     One element in a sequence
     """
-    sequence = models.ForeignKey(Sequence, on_delete=models.CASCADE)
+    sequence = models.ForeignKey(Sequence, on_delete=models.CASCADE,
+                                 related_name='sequence_enumerated_elements')
     page_element = models.ForeignKey(PageElement, on_delete=models.CASCADE)
     rank = models.IntegerField(
         help_text=_("used to order elements when presenting a sequence."))

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -27,11 +27,11 @@ import json
 
 import bleach
 from rest_framework import serializers
+from django.contrib.auth import get_user_model
 
 from . import settings
 from .compat import gettext_lazy as _, is_authenticated
 from .models import Comment, Follow, PageElement, Vote, Sequence, EnumeratedElements
-
 
 #pylint: disable=no-init,abstract-method
 
@@ -268,35 +268,31 @@ class EnumeratedElementSerializer(serializers.ModelSerializer):
     Serializes an EnumeratedElement
     """
 
-    page_element = serializers.SerializerMethodField()
+    page_element = serializers.SlugRelatedField(
+        queryset=PageElement.objects.all(),
+        slug_field="slug",
+        help_text=_("Page element the enumerated element is for"),
+        required=False)
 
     class Meta:
         model = EnumeratedElements
         fields = ('page_element', 'rank', 'min_viewing_duration')
 
-    @staticmethod
-    def get_page_element(obj):
-        if hasattr(obj.page_element, 'slug'):
-            return obj.page_element.slug
-        return obj.page_element
-
-
-class UpdateEnumeratedElementSerializer(serializers.ModelSerializer):
-    """
-    Serializes an EnumeratedElement for update
-    """
-    class Meta:
-        model = EnumeratedElements
-        fields = ('page_element', 'rank', 'min_viewing_duration',)
-
 
 class SequenceSerializer(serializers.ModelSerializer):
+    """
+    Serializes a Sequence
+    """
     elements = serializers.SerializerMethodField()
-    account = serializers.SerializerMethodField()
+    account = serializers.SlugRelatedField(
+        queryset=get_user_model().objects.all(),
+        slug_field=settings.ACCOUNT_LOOKUP_FIELD,
+        help_text=_("Account the sequence belongs to"),
+        required=False)
 
     class Meta:
         model = Sequence
-        fields = (('id', 'created_at', 'slug', 'title', 'account', 'extra')
+        fields = (('created_at', 'slug', 'title', 'account', 'extra')
                   + ('elements',))
 
     @staticmethod
@@ -304,22 +300,3 @@ class SequenceSerializer(serializers.ModelSerializer):
         return EnumeratedElementSerializer(
             obj.sequence_enumerated_elements.all().order_by('rank'),
             many=True).data
-
-    @staticmethod
-    def get_account(obj):
-        account_lookup_field = getattr(settings, 'ACCOUNT_LOOKUP_FIELD',
-                                       'username')
-        if hasattr(obj.account, account_lookup_field):
-            return getattr(obj.account, account_lookup_field)
-        return obj.account
-
-# pylint: disable=too-few-public-methods
-class UpdateSequenceSerializer(serializers.ModelSerializer):
-    '''
-    Serializer to update/create a Sequence
-    '''
-
-    class Meta:
-        model = Sequence
-        fields = ('created_at', 'slug', 'title', 'account', 'extra')
-        read_only_fields = ('created_at',)

--- a/pages/urls/api/__init__.py
+++ b/pages/urls/api/__init__.py
@@ -25,8 +25,12 @@
 '''API URLs for the pages application'''
 
 from ...api.elements import (PageElementEditableListAPIView,
-    PageElementIndexAPIView)
+    PageElementIndexAPIView, SequenceAPIView)
 from ...compat import include, path
+from rest_framework.routers import DefaultRouter
+
+router = DefaultRouter()
+router.register(r'sequences', SequenceAPIView, basename='pages_api_sequence')
 
 
 urlpatterns = [
@@ -38,3 +42,4 @@ urlpatterns = [
     path('content', PageElementIndexAPIView.as_view(),
         name="api_content_index"),
 ]
+urlpatterns += router.urls

--- a/pages/urls/api/__init__.py
+++ b/pages/urls/api/__init__.py
@@ -29,9 +29,8 @@ from ...api.elements import (PageElementEditableListAPIView,
 from ...compat import include, path
 from rest_framework.routers import DefaultRouter
 
-router = DefaultRouter()
+router = DefaultRouter(trailing_slash=False)
 router.register(r'sequences', SequenceAPIView, basename='pages_api_sequence')
-
 
 urlpatterns = [
     path('content/editables/', include('pages.urls.api.editables')),


### PR DESCRIPTION
`elements.py`:
- Added SequenceAPIView to list, create, update, or delete Sequence objects.
- Includes add_element and remove_element custom actions to add/remove EnumeratedElements.

`serializers.py`:
- UpdateEnumeratedElementSerializer: Serializer for updating enumeratedelements, where page_element is a queryset of all available page_elements.
- SequenceSerializer with elements listed for the sequence.
