### PR TITLE
[Work-in-Progress] Download a certificate of completion(#76)

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -455,6 +455,8 @@ class SequenceProgress(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
+    completion_date = models.DateTimeField(
+        help_text=_("Time when the user completed the Sequence"))
 
     def __str__(self):
         return "%s-%s" % (self.sequence, self.user)

--- a/pages/templates/pages/certificate.html
+++ b/pages/templates/pages/certificate.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Certificate of Completion</title>
+</head>
+<body>
+    <div class="certificate">
+        <div>Certificate of Completion</div>
+        <div>This is to certify that</div>
+        <div>{{ user.username }}</div>
+        <div>
+            has successfully completed the <strong>{{ sequence.title }}</strong> sequence.
+        </div>
+        <div>Date: {{ current_date|date:"F j, Y" }}</div>
+    </div>
+</body>
+</html>

--- a/pages/templates/pages/certificate.html
+++ b/pages/templates/pages/certificate.html
@@ -11,7 +11,7 @@
         <div>
             has successfully completed the <strong>{{ sequence.title }}</strong> sequence.
         </div>
-        <div>Date: {{ current_date|date:"F j, Y" }}</div>
+        <div>Date: {{ completion_date|date:"F j, Y" }}</div>
     </div>
 </body>
 </html>

--- a/pages/urls/views/elements.py
+++ b/pages/urls/views/elements.py
@@ -23,11 +23,11 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from ... import settings
-from ...compat import re_path, path
+from ...compat import re_path
 from ...views.elements import PageElementView, CertificateDownloadView
 
 urlpatterns = [
-    re_path(r'^(?P<sequence_slug>%s)/certificate/' % settings.SLUG_RE,
+    re_path(r'^(?P<sequence_slug>%s)/certificate' % settings.SLUG_RE,
          CertificateDownloadView.as_view(),
          name='certificate_download'),
     re_path(r'^(?P<path>%s)$' % settings.PATH_RE,

--- a/pages/urls/views/elements.py
+++ b/pages/urls/views/elements.py
@@ -23,10 +23,13 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from ... import settings
-from ...compat import re_path
-from ...views.elements import PageElementView
+from ...compat import re_path, path
+from ...views.elements import PageElementView, CertificateDownloadView
 
 urlpatterns = [
+    re_path(r'^(?P<sequence_slug>%s)/certificate/' % settings.SLUG_RE,
+         CertificateDownloadView.as_view(),
+         name='certificate_download'),
     re_path(r'^(?P<path>%s)$' % settings.PATH_RE,
         PageElementView.as_view(), name='pages_element'),
     re_path(r'^$',

--- a/pages/urls/views/elements.py
+++ b/pages/urls/views/elements.py
@@ -23,11 +23,11 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from ... import settings
-from ...compat import re_path
+from ...compat import re_path, path
 from ...views.elements import PageElementView, CertificateDownloadView
 
 urlpatterns = [
-    re_path(r'^(?P<sequence_slug>%s)/certificate' % settings.SLUG_RE,
+    path('<sequence>/certificate/',
          CertificateDownloadView.as_view(),
          name='certificate_download'),
     re_path(r'^(?P<path>%s)$' % settings.PATH_RE,

--- a/pages/urls/views/elements.py
+++ b/pages/urls/views/elements.py
@@ -27,7 +27,7 @@ from ...compat import re_path, path
 from ...views.elements import PageElementView, CertificateDownloadView
 
 urlpatterns = [
-    path('<sequence>/certificate/',
+    path('<slug:sequence>/certificate/',
          CertificateDownloadView.as_view(),
          name='certificate_download'),
     re_path(r'^(?P<path>%s)$' % settings.PATH_RE,

--- a/testsite/settings.py
+++ b/testsite/settings.py
@@ -91,6 +91,10 @@ LOGGING = {
         }
     },
     'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
         'logfile':{
             'level':'DEBUG',
             'class':'logging.StreamHandler',
@@ -129,6 +133,10 @@ LOGGING = {
         '': {
             'handlers': ['logfile', 'mail_admins'],
             'level': 'INFO'
+        },
+        'fontTools.subset': {
+            'handlers': ['console'],
+            'level': 'WARNING',
         }
     }
 }


### PR DESCRIPTION
Allows downloading a certificate of completion at the /sequence_slug/certificate URL after all elements in the sequence have been viewed.
- `settings.py`: Updated logger to only show warning messages and not the font subsetting and optimization messages that show up due to fontTools