### PR TITLE
[Work-in-Progress] Enables markdown for PageElement text (#80)

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -169,11 +169,18 @@ class PageElement(models.Model):
     Elements of an editable HTML page.
     """
     objects = PageElementManager()
+    FORMAT_CHOICES = (
+        ('HTML', 'HTML'),
+        ('MD', 'Markdown'),
+    )
 
     slug = models.SlugField(unique=True,
         help_text=_("Unique identifier that can be used in URL paths"))
     title = models.CharField(max_length=1024, blank=True,
         help_text=_("Title of the page element"))
+    content_format = models.CharField(
+        max_length=4, choices=FORMAT_CHOICES, default='HTML',
+        help_text=_("Designate whether the text field is HTML or Markdown"))
     text = models.TextField(blank=True,
         help_text=_("Long description of the page element"))
     account = models.ForeignKey(

--- a/pages/templates/pages/element.html
+++ b/pages/templates/pages/element.html
@@ -5,7 +5,7 @@
   <editables-detail inline-template>
     <div :id="item.slug">
         <h1 class="editable" data-key="title">[[item.title]]</h1>
-        <div class="editable edit-formatted" data-key="text" v-html="item.text" v-if="item.text">
+        <div class="editable edit-formatted" data-key="text" v-html="item.html_formatted" v-if="item.text">
         </div>
         <div class="editable edit-formatted" data-key="text" v-if="!item.text">
             enter text here...


### PR DESCRIPTION
- Added content_format to PageElement model
- Added content_format to PageElementSerializer, which checks if text is Markdown or HTML, and then uses the HTMLField to "sanitize" the field. 