### PR TITLE
[Work-in-Progress] Allow marking webinar attendance via API endpoint(#77)

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -397,8 +397,6 @@ class LiveEvent(models.Model):
     scheduled_at = models.DateTimeField()
     location = models.URLField(_("URL to the calendar event"), max_length=2083)
     max_attendees = models.IntegerField(default=0)
-    sequence = models.ForeignKey('Sequence', on_delete=models.CASCADE,
-         related_name='sequence_events')
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
 
@@ -457,7 +455,7 @@ class SequenceProgress(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
-    completion_date = models.DateTimeField(
+    completion_date = models.DateTimeField(blank=True, null=True,
         help_text=_("Time when the user completed the Sequence"))
 
     def __str__(self):

--- a/pages/models.py
+++ b/pages/models.py
@@ -397,6 +397,8 @@ class LiveEvent(models.Model):
     scheduled_at = models.DateTimeField()
     location = models.URLField(_("URL to the calendar event"), max_length=2083)
     max_attendees = models.IntegerField(default=0)
+    sequence = models.ForeignKey('Sequence', on_delete=models.CASCADE,
+         related_name='sequence_events')
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
 

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -29,6 +29,7 @@ import bleach
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.shortcuts import get_object_or_404
 
 
 from . import settings
@@ -349,3 +350,14 @@ class EnumeratedProgressPingSerializer(serializers.ModelSerializer):
     class Meta:
         model = EnumeratedProgress
         fields = ('created_at', 'viewing_duration', 'last_ping_time')
+
+class AttendanceInputSerializer(serializers.Serializer):
+    sequence = serializers.SlugField()
+    username = serializers.CharField()
+    rank = serializers.IntegerField()
+
+    def validate_sequence(self, value):
+        return get_object_or_404(Sequence, slug=value)
+
+    def validate_username(self, value):
+        return get_object_or_404(get_user_model(), username=value)

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -352,6 +352,10 @@ class EnumeratedProgressPingSerializer(serializers.ModelSerializer):
         fields = ('created_at', 'viewing_duration', 'last_ping_time')
 
 class AttendanceInputSerializer(serializers.Serializer):
+    """
+    Serializer to validate input to mark users' attendance
+    to a LiveEvent(LiveEventAttendanceAPIView)
+    """
     sequence = serializers.SlugField()
     username = serializers.CharField()
     rank = serializers.IntegerField()

--- a/pages/urls/api/progress.py
+++ b/pages/urls/api/progress.py
@@ -27,7 +27,7 @@ API URLs for EnumeratedProgress objects
 """
 
 from ...api.progress import EnumeratedProgressAPIView
-from django.urls import path
+from ...compat import path
 
 urlpatterns = [
     path('<slug:sequence>',

--- a/pages/urls/api/sequences.py
+++ b/pages/urls/api/sequences.py
@@ -36,7 +36,7 @@ router.register(r'sequences',
                 SequenceAPIView,
                 basename='api_sequences')
 urlpatterns = [
-    path('sequences/<slug:sequence>/<int:rank>/events/<username>/mark-attendance',
+    path('sequences/<slug:sequence>/<int:rank>/<username>/mark-attendance',
          LiveEventAttendanceAPIView.as_view(),
          name='api_mark_attendance')
 ] + router.urls

--- a/pages/urls/api/sequences.py
+++ b/pages/urls/api/sequences.py
@@ -26,12 +26,17 @@
 API URLs for sequence objects
 """
 
-from ...api.sequences import (SequenceAPIView)
+from ...api.sequences import (SequenceAPIView, LiveEventAttendanceAPIView)
 from rest_framework.routers import DefaultRouter
+
+from ...compat import path
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r'sequences',
                 SequenceAPIView,
                 basename='api_sequences')
 urlpatterns = [
+    path('sequences/<slug:sequence>/<int:rank>/events/<username>/mark-attendance',
+         LiveEventAttendanceAPIView.as_view(),
+         name='api_mark_attendance')
 ] + router.urls


### PR DESCRIPTION
- Added an API endpoint to allow marking a user's attendance to a LiveEvent. 
- Added a Sequence ForeignKey to the LiveEvent model
- Added a serializer to validate URL kwargs.
- Added URL(Might be a little too long, though)