### PR TITLE
[Work-in-Progress] Added API endpoint to allow importing Docx files(#81)

### DIFF
--- a/pages/api/elements.py
+++ b/pages/api/elements.py
@@ -28,7 +28,8 @@ from io import BytesIO
 
 from bs4 import BeautifulSoup
 from django.core.exceptions import ValidationError
-from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.files.uploadedfile import (SimpleUploadedFile,
+    TemporaryUploadedFile)
 from django.db import transaction
 from django.db.models import Max, Q
 from django.http import Http404
@@ -734,7 +735,9 @@ class ImportDocxView(AccountMixin, APIView):
         page_element = PageElement.objects.filter(slug=page_element_slug).first()
         if not page_element:
             return api_response.Response({'detail': 'Page Element not found'})
-        if docx_location.startswith(("http://", "https://", "www.")):
+        if isinstance(docx_location, TemporaryUploadedFile):
+            docx_content = docx_location
+        elif docx_location.startswith(("http://", "https://", "www.")):
             response = requests.get(self.format_drive_url(docx_location), stream=True)
             docx_content = BytesIO(response.content)
         else:

--- a/pages/urls/api/__init__.py
+++ b/pages/urls/api/__init__.py
@@ -25,10 +25,11 @@
 '''API URLs for the pages application'''
 
 from ...api.elements import (PageElementEditableListAPIView,
-    PageElementIndexAPIView)
+    PageElementIndexAPIView, ImportDocxView)
 from ...compat import include, path
 
 urlpatterns = [
+    path('import-docx', ImportDocxView.as_view(), name='import_docx'),
     path('content/editables/', include('pages.urls.api.editables')),
     path('content/editables', PageElementEditableListAPIView.as_view(),
         name='pages_api_editables_index'),


### PR DESCRIPTION
Abandoned the manage.py function in favor of an API endpoint to make managing uploading images easier. 

- Receives a docx_location from the request data, check if it's a URL to a google doc, an uploaded file, or the path to a file on the system.

- Converts it from docx to HTML, because the options for directly converting to Markdown are limited and this lets us get images from the docx file much more easily. 

- Extracts and uploads images to system, if there are any in the docx file. Here we're using the functionality in the UploadAssetAPIView. Changed the view to use a helper function and imported that helper function here. Other options were using the requests library to send a request to the API endpoint or using the Django RequestFactory to call the asset upload API endpoint from within this view. Both were recommended less than this approach.

- We then convert it to Markdown if required and save the page_element's text with the extracted data from the docx with relevant tables, images, and other formatting.


Notes:
- The documentation is currently minimal. Will update once this approach is reviewed and approved. 
- Left `page_element.content_format = ...` commented in there for when #82 is merged.