### PR TITLE
[Work-in-Progress] Allow adding a Certificate to a Sequence

### DIFF
--- a/pages/api/sequences.py
+++ b/pages/api/sequences.py
@@ -296,6 +296,9 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
         Sets the Sequence's has_certificate field to True, enabling Certificates
         for users that complete the Sequence.
 
+        The EnumeratedElement with the highest rank in the sequence is
+        then considered the certificate.
+
         .. code-block:: http
 
             PATCH /api/sequences/sequence1/certificate HTTP/1.1
@@ -307,6 +310,7 @@ class SequenceAPIView(viewsets.ModelViewSet): # pylint: disable=too-many-ancesto
             }
             """
         sequence = self.get_object()
+
         if not sequence.has_certificate:
             sequence.has_certificate = True
             sequence.save()

--- a/pages/models.py
+++ b/pages/models.py
@@ -304,23 +304,6 @@ class PageElement(models.Model):
 
 
 @python_2_unicode_compatible
-class Certificate(models.Model):
-    """
-    A Certificate of completion
-
-    Used to download a certificate of completion for a sequence.
-    """
-    created_at = models.DateTimeField(editable=False, auto_now_add=True)
-    element = models.ForeignKey(PageElement, on_delete=models.CASCADE,
-        related_name='certificate')
-    extra = get_extra_field_class()(null=True, blank=True,
-        help_text=_("Extra meta data (can be stringify JSON)"))
-
-    def __str__(self):
-        return "%s-certificate" % str(self.element)
-
-
-@python_2_unicode_compatible
 class Comment(models.Model):
     """
     A user comments about a PageElement.
@@ -417,9 +400,9 @@ class Sequence(models.Model):
     account = models.ForeignKey(
         settings.ACCOUNT_MODEL, related_name='account_sequences',
         null=True, on_delete=models.SET_NULL)
+    has_certificate = models.BooleanField(default=False)
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
-
     def __str__(self):
         return "%s" % str(self.slug)
 
@@ -453,10 +436,11 @@ class SequenceProgress(models.Model):
     created_at = models.DateTimeField(editable=False, auto_now_add=True)
     sequence = models.ForeignKey(Sequence, on_delete=models.CASCADE)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    completion_date = models.DateTimeField(
+        help_text=_("Time when the user completed the Sequence"),
+        blank=True, null=True)
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
-    completion_date = models.DateTimeField(
-        help_text=_("Time when the user completed the Sequence"))
 
     def __str__(self):
         return "%s-%s" % (self.sequence, self.user)

--- a/pages/models.py
+++ b/pages/models.py
@@ -416,7 +416,7 @@ class Sequence(models.Model):
     @property
     def get_certificate(self):
         if self.has_certificate:
-            return self.sequence_enumerated_elements.order_by('rank').last()
+            return self.sequence_enumerated_elements.order_by('rank').last().page_element
         return None
 
 
@@ -471,7 +471,7 @@ class SequenceProgress(models.Model):
     def is_completed(self):
         if self.sequence.has_certificate:
             # We exclude the element with the highest rank
-            certificate_element = self.sequence.get_certificate.page_element
+            certificate_element = self.sequence.get_certificate
             enumerated_elements = EnumeratedElements.objects.filter(
                 sequence=self.sequence).exclude(
                 page_element__slug=certificate_element.slug)

--- a/pages/models.py
+++ b/pages/models.py
@@ -443,7 +443,8 @@ class EnumeratedElements(models.Model):
     @property
     def is_certificate(self):
         if self.sequence.has_certificate:
-            last_element_rank = self.sequence.sequence_enumerated_elements.order_by('rank').last().rank
+            last_element_rank = (self.sequence.sequence_enumerated_elements.
+                                 order_by('rank').last().rank)
             return self.rank == last_element_rank
         return False
 

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -297,10 +297,19 @@ class EnumeratedElementSerializer(serializers.ModelSerializer):
         slug_field="slug",
         help_text=_("Page element the enumerated element is for"),
         required=False)
+    certificate = serializers.BooleanField(
+        write_only=True, default=False,
+        help_text=_("Field to indicate if the PageElement being added "
+                    "to the Sequence is a Certificate"))
 
     class Meta:
         model = EnumeratedElements
-        fields = ('page_element', 'rank', 'min_viewing_duration')
+        fields = ('page_element', 'rank', 'min_viewing_duration', 'certificate')
+
+    def create(self, validated_data):
+        validated_data.pop('certificate', None)
+
+        return EnumeratedElements.objects.create(**validated_data)
 
 
 class SequenceSerializer(serializers.ModelSerializer):
@@ -316,8 +325,8 @@ class SequenceSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Sequence
-        fields = (('created_at', 'slug', 'title', 'account', 'extra')
-                  + ('elements',))
+        fields = (('created_at', 'slug', 'title', 'account', 'has_certificate',
+                   'extra') + ('elements',))
 
     @staticmethod
     def get_elements(obj):

--- a/pages/static/js/djaodjin-pages-vue.js
+++ b/pages/static/js/djaodjin-pages-vue.js
@@ -603,7 +603,7 @@ Vue.component('sequence-items', {
         itemListMixin],
     data() {
         return {
-            url: this.$urls.api_enumerated_progress_user_list,
+            url: this.$urls.api_enumerated_progress_user_list
         };
     },
     mounted() {

--- a/pages/templates/pages/app/sequences/index.html
+++ b/pages/templates/pages/app/sequences/index.html
@@ -10,21 +10,37 @@
                 <ul>
                     {% for element in elements %}
                     <li>
+                        {% if element.is_live_event %}
+                            <span class="live-event-label">
+                                <a href="{% url 'sequences:sequence_page_element_view' sequence=element.sequence.slug rank=element.rank %}">
+                            {{ element_titles|get_item:element.rank }}</a>({{ element.rank }}) -
+                                Live Event:</span>
+                        {% elif element.is_certificate %}
+                            <span class="certificate-label">
+                            <a href="{% url 'certificate_download' sequence=element.sequence.slug %}">
+                                {{ element_titles|get_item:element.rank }}</a>({{ element.rank }}) - Certificate
+                            </span>
+                        {% else %}
                         <a href="{% url 'sequences:sequence_page_element_view' sequence=element.sequence.slug rank=element.rank %}">
                             {{ element_titles|get_item:element.rank }}</a>({{ element.rank }}) -
-                        <template v-for="item in items.results">
-                            <span v-if="item.rank === {{ element.rank }}">
-                                [[ item.viewing_duration | formatDuration ]]
-                            </span>
-                        </template>
-                        <span v-if="!items.results.some(item => item.rank === {{ element.rank }})">
+
+                        <span v-if="items.results.some(item => item.rank === {{ element.rank }})">
+                            <template v-for="item in items.results">
+                                <span v-if="item.rank === {{ element.rank }}">
+                                    <span v-if="{{ element.is_live_event }}"></span>
+                                    [[ item.viewing_duration | formatDuration ]]
+                                </span>
+                            </template>
+                        </span>
+                        <span v-else>
                             No progress yet
                         </span>
+                    {% endif %}
                     </li>
                     {% endfor %}
                 </ul>
             </div>
-        {% include '_paginator.html' %}
+            {% include '_paginator.html' %}
         </div>
     </sequence-items>
 </section>

--- a/pages/templates/pages/app/sequences/index.html
+++ b/pages/templates/pages/app/sequences/index.html
@@ -12,22 +12,21 @@
                     <li>
                         {% if element.is_live_event %}
                             <span class="live-event-label">
-                                <a href="{% url 'sequences:sequence_page_element_view' sequence=element.sequence.slug rank=element.rank %}">
-                            {{ element_titles|get_item:element.rank }}</a>({{ element.rank }}) -
+                                <a href="{{ element.url }}">
+                            {{ element.title }}</a>({{ element.rank }}) -
                                 Live Event:</span>
                         {% elif element.is_certificate %}
                             <span class="certificate-label">
-                            <a href="{% url 'certificate_download' sequence=element.sequence.slug %}">
-                                {{ element_titles|get_item:element.rank }}</a>({{ element.rank }}) - Certificate
+                            <a href="{{ urls.certificate_download }}">
+                                {{ element.title }}</a>({{ element.rank }}) - Certificate
                             </span>
                         {% else %}
-                        <a href="{% url 'sequences:sequence_page_element_view' sequence=element.sequence.slug rank=element.rank %}">
-                            {{ element_titles|get_item:element.rank }}</a>({{ element.rank }}) -
+                        <a href="{{ element.url }}">
+                            {{ element.title }}</a>({{ element.rank }}) -
 
                         <span v-if="items.results.some(item => item.rank === {{ element.rank }})">
                             <template v-for="item in items.results">
                                 <span v-if="item.rank === {{ element.rank }}">
-                                    <span v-if="{{ element.is_live_event }}"></span>
                                     [[ item.viewing_duration | formatDuration ]]
                                 </span>
                             </template>

--- a/pages/templates/pages/app/sequences/pageelement.html
+++ b/pages/templates/pages/app/sequences/pageelement.html
@@ -2,7 +2,7 @@
 
 {% block content %}
     <br>
-    <a href="{% url 'sequences:sequence_progress_view' sequence=sequence.slug %}">
+    <a href="{{ urls.sequence_progress_view }}">
         Back to {{ sequence.slug }}
     </a>
 
@@ -15,10 +15,10 @@
 
 
     {% if element.is_live_event %}
-        <p>Live Event URL: <a href="{{ element.page_element.events.first.location }}">{{ element.page_element.events.first.location }}</a></p>
+        <p>Live Event URL: <a href="{{ urls.live_event_location }}">{{ element.page_element.events.first.location }}</a></p>
 
     {% elif element.is_certificate %}
-        <p>This is a certificate. <a href="{% url 'certificate_download' sequence=sequence.slug %}">Download Certificate</a></p>
+        <p>This is a certificate. <a href="{{ urls.certificate_download }}">Download Certificate</a></p>
     {% else %}
         {% if not progress %}
             <p>No progress yet!</p>
@@ -50,13 +50,13 @@
     {% endif %}
 
     {% if previous_element %}
-        <a href="{% url 'sequences:sequence_page_element_view' sequence=sequence.slug rank=previous_element.rank %}">
+        <a href="{{ previous_element.url }}">
             Previous
         </a>
     {% endif %}
 
     {% if next_element %}
-        <a href="{% url 'sequences:sequence_page_element_view' sequence=sequence.slug rank=next_element.rank %}">
+        <a href="{{ next_element.url }}">
             Next
         </a>
     {% endif %}

--- a/pages/templates/pages/app/sequences/pageelement.html
+++ b/pages/templates/pages/app/sequences/pageelement.html
@@ -13,6 +13,42 @@
         <hr>
     {% endif %}
 
+
+    {% if element.is_live_event %}
+        <p>Live Event URL: <a href="{{ element.page_element.events.first.location }}">{{ element.page_element.events.first.location }}</a></p>
+
+    {% elif element.is_certificate %}
+        <p>This is a certificate. <a href="{% url 'certificate_download' sequence=sequence.slug %}">Download Certificate</a></p>
+    {% else %}
+        {% if not progress %}
+            <p>No progress yet!</p>
+            <section id="app">
+                <start-progress inline-template
+                    :sequence-slug="'{{ sequence.slug }}'"
+                    :user-username="'{{ request.user.username }}'"
+                    :element-rank="{{ element.rank }}">
+                    <div>
+                        <button id="startProgress" @click="startProgress">Start Progress</button>
+                        <p>Click the button to start tracking your progress.</p>
+                    </div>
+                </start-progress>
+            </section>
+        {% else %}
+            <section id="app">
+                <viewing-timer inline-template
+                    :initial-duration="{{ viewing_duration_seconds }}"
+                    :rank="{{ element.rank }}"
+                    :sequence="'{{ sequence.slug }}'"
+                    :user="'{{ request.user.username }}'"
+                    :ping-interval="{{ ping_interval }}">
+                    <div>
+                        <label>Viewing Duration:</label> <span>[[ duration | formatDuration ]]</span>
+                    </div>
+                </viewing-timer>
+            </section>
+        {% endif %}
+    {% endif %}
+
     {% if previous_element %}
         <a href="{% url 'sequences:sequence_page_element_view' sequence=sequence.slug rank=previous_element.rank %}">
             Previous
@@ -25,33 +61,4 @@
         </a>
     {% endif %}
     <br>
-
-    {% if not progress %}
-        <p>No progress yet!</p>
-        <section id="app">
-            <start-progress inline-template
-                :sequence-slug="'{{ sequence.slug }}'"
-                :user-username="'{{ request.user.username }}'"
-                :element-rank="{{ element.rank }}">
-                <div>
-                    <button id="startProgress" @click="startProgress">Start Progress</button>
-                    <p>Click the button to start tracking your progress.</p>
-                </div>
-            </start-progress>
-        </section>
-    {% else %}
-        <section id="app">
-            <viewing-timer inline-template
-                :initial-duration="{{ viewing_duration_seconds }}"
-                :rank="{{ element.rank }}"
-                :sequence="'{{ sequence.slug }}'"
-                :user="'{{ request.user.username }}'"
-                :ping-interval="{{ ping_interval }}">
-                <div>
-                    <label>Viewing Duration:</label> <span>[[ duration | formatDuration ]]</span>
-                </div>
-            </viewing-timer>
-        </section>
-    {% endif %}
-
 {% endblock %}

--- a/pages/templates/pages/certificate.html
+++ b/pages/templates/pages/certificate.html
@@ -4,6 +4,7 @@
     <title>Certificate of Completion</title>
 </head>
 <body>
+{{ certificate.text|safe }}
     <div class="certificate">
         <div>Certificate of Completion</div>
         <div>This is to certify that</div>

--- a/pages/views/elements.py
+++ b/pages/views/elements.py
@@ -245,6 +245,7 @@ class CertificateDownloadView(DetailView):
             'user': self.request.user,
             'sequence': sequence,
             'has_certificate': sequence.has_certificate,
+            'certificate': sequence.get_certificate,
             'has_completed_sequence': has_completed_sequence
         })
 

--- a/pages/views/elements.py
+++ b/pages/views/elements.py
@@ -27,8 +27,7 @@ from datetime import datetime
 from django.db.models import Exists, OuterRef
 from django.http import HttpResponseForbidden, Http404
 from django.shortcuts import get_object_or_404
-from django.views.generic.detail import DetailView
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, DetailView
 
 from deployutils.apps.django.mixins import AccessiblesMixin
 from extended_templates.backends.pdf import PdfTemplateResponse
@@ -280,9 +279,5 @@ class CertificateDownloadView(DetailView):
             return HttpResponseForbidden(
                 'A certificate is not available for download.')
 
-        return self.response_class(
-            request=request,
-            template=self.get_template_names(),
-            context=context,
-        )
+        return self.render_to_response(context)
 

--- a/testsite/fixtures/default-db.json
+++ b/testsite/fixtures/default-db.json
@@ -97,6 +97,17 @@
 },
 {
   "fields": {
+    "title": "Certificate of Completion",
+    "slug": "certificate-of-completion",
+    "extra": "{\"searchable\":true,\"visibility\":[\"public\"]}",
+    "account": 2,
+    "text": "<h2>Congratulations!</h2><p>You have completed the course.</p>"
+  },
+      "model": "pages.PageElement", "pk": 108
+},
+
+{
+  "fields": {
     "title": "Sequence without Certificate",
     "slug": "seq",
     "account": 2,
@@ -163,7 +174,7 @@
 {
   "fields": {
     "sequence": 102,
-    "page_element": 102,
+    "page_element": 108,
     "rank": 3,
     "min_viewing_duration": "00:00:30"
   },
@@ -220,7 +231,7 @@
 {
   "fields": {
     "sequence": 103,
-    "page_element": 102,
+    "page_element": 108,
     "rank": 4,
     "min_viewing_duration": "00:00:00"
   },

--- a/testsite/fixtures/default-db.json
+++ b/testsite/fixtures/default-db.json
@@ -84,4 +84,146 @@
     "orig_element": 104, "dest_element": 106
   },
   "model": "pages.RelationShip", "pk": 105
-}]
+},
+{
+  "fields": {
+    "title": "Webinar on Sustainability",
+    "slug": "sustainability-webinar",
+    "extra": "{\"searchable\":true,\"visibility\":[\"public\"]}",
+    "account": 2,
+    "text": "<h2>Join our Webinar!</h2><p>Learn about sustainability practices.</p>"
+  },
+      "model": "pages.PageElement", "pk": 107
+},
+{
+  "fields": {
+    "title": "Sequence without Certificate",
+    "slug": "seq",
+    "account": 2,
+    "has_certificate": false,
+    "created_at": "2023-01-01T00:00:00Z"
+  },
+  "model": "pages.Sequence", "pk": 101
+},
+{
+    "fields": {
+      "sequence": 101,
+      "page_element": 100,
+      "rank": 1,
+      "min_viewing_duration": "00:00:10"
+    },
+  "model": "pages.EnumeratedElements", "pk": 101
+},
+{
+    "fields": {
+      "sequence": 101,
+      "page_element": 101,
+      "rank": 2,
+      "min_viewing_duration": "00:00:20"
+    },
+  "model": "pages.EnumeratedElements", "pk": 102
+},
+{
+    "fields": {
+      "sequence": 101,
+      "page_element": 102,
+      "rank": 3,
+      "min_viewing_duration": "00:00:30"
+    },
+  "model": "pages.EnumeratedElements", "pk": 103
+},
+{
+  "fields": {
+    "title": "Sequence with Certificate",
+    "slug": "seq-cert",
+    "account": 2,
+    "has_certificate": true,
+    "created_at": "2023-01-02T00:00:00Z"
+  },
+    "model": "pages.Sequence", "pk": 102
+},
+{
+  "fields": {
+    "sequence": 102,
+    "page_element": 100,
+    "rank": 1,
+    "min_viewing_duration": "00:00:10"
+  },
+    "model": "pages.EnumeratedElements", "pk": 104
+},
+{
+  "fields": {
+    "sequence": 102,
+    "page_element": 101,
+    "rank": 2,
+    "min_viewing_duration": "00:00:20"
+  },
+    "model": "pages.EnumeratedElements", "pk": 105
+},
+{
+  "fields": {
+    "sequence": 102,
+    "page_element": 102,
+    "rank": 3,
+    "min_viewing_duration": "00:00:30"
+  },
+    "model": "pages.EnumeratedElements",   "pk": 106
+},
+{
+    "fields": {
+      "element": 107,
+      "created_at": "2023-03-15T10:00:00Z",
+      "scheduled_at": "2023-04-10T15:00:00Z",
+      "location": "http://127.0.0.1:8000/webinar/sustainability",
+      "max_attendees": 100,
+      "extra": "{}"
+    },
+    "model": "pages.LiveEvent", "pk": 200
+},
+{
+  "fields": {
+    "title": "Sequence with Certificate And Live Event",
+    "slug": "seq-cert-live_event",
+    "account": 2,
+    "has_certificate": true,
+    "created_at": "2023-01-03T00:00:00Z"
+  },
+    "model": "pages.Sequence", "pk": 103
+},
+{
+  "fields": {
+    "sequence": 103,
+    "page_element": 100,
+    "rank": 1,
+    "min_viewing_duration": "00:00:10"
+  },
+    "model": "pages.EnumeratedElements", "pk": 107
+},
+{
+  "fields": {
+    "sequence": 103,
+    "page_element": 101,
+    "rank": 2,
+    "min_viewing_duration": "00:00:20"
+  },
+    "model": "pages.EnumeratedElements", "pk": 108
+},
+{
+  "fields": {
+    "sequence": 103,
+    "page_element": 107,
+    "rank": 3,
+    "min_viewing_duration": "00:00:30"
+  },
+    "model": "pages.EnumeratedElements",   "pk": 109
+},
+{
+  "fields": {
+    "sequence": 103,
+    "page_element": 102,
+    "rank": 4,
+    "min_viewing_duration": "00:00:00"
+  },
+    "model": "pages.EnumeratedElements",   "pk": 110
+}
+]

--- a/testsite/fixtures/default-db.json
+++ b/testsite/fixtures/default-db.json
@@ -225,5 +225,4 @@
     "min_viewing_duration": "00:00:00"
   },
     "model": "pages.EnumeratedElements",   "pk": 110
-}
-]
+}]


### PR DESCRIPTION
- Updated logic for checking progress completion
- Updated sequences page to display each EnumeratedElement while accounting for certificates and live events.
- Added properties on EnumeratedElements to indicate LiveEvent or Certificate status.

Notes:
- The last element of a sequence is considered its certificate
- The API view simply sets has_certificate to True, then the user has to add a PageElement with the highest rank for it to be the certificate.
