### PR TITLE
Scheduling of Live Events(#77)

### DIFF
--- a/pages/api/sequences.py
+++ b/pages/api/sequences.py
@@ -404,10 +404,6 @@ class AddElementToSequenceAPIView(AccountMixin, SequenceMixin,
                 {'detail': str(err)},
                 status=status.HTTP_400_BAD_REQUEST)
 
-        # return api_response.Response(
-        #     serializer.errors,
-        #     status=status.HTTP_400_BAD_REQUEST)
-
 
 class RemoveElementFromSequenceAPIView(AccountMixin, SequenceMixin,
                                        DestroyAPIView):
@@ -447,15 +443,14 @@ class LiveEventListCreateAPIView(AccountMixin, PageElementMixin, ListCreateAPIVi
         queryset = LiveEvent.objects.filter(
             element=self.element
             ).order_by('-status', 'rank')
-        # if self.element_url_kwarg in self.kwargs:
-        #     queryset = queryset.filter(element=self.element)
+
         return queryset
 
     def get(self, request, *args, **kwargs):
-        return self.list(request, *args, **kwargs)
+        return super(LiveEventListCreateAPIView, self).get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        return self.create(request, *args, **kwargs)
+        return super(LiveEventListCreateAPIView, self).post(request, *args, **kwargs)
 
     def perform_create(self, serializer):
         serializer.save(element=self.element, status='scheduled')
@@ -476,6 +471,6 @@ class LiveEventRetrieveUpdateDestroyAPIView(PageElementMixin, RetrieveUpdateDest
 
     def delete(self, request, *args, **kwargs):
         live_event = self.get_object()
-        live_event.status = 'cancelled'
+        live_event.status = 'CANCELLED'
         live_event.save()
         return api_response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/pages/api/sequences.py
+++ b/pages/api/sequences.py
@@ -453,7 +453,7 @@ class LiveEventListCreateAPIView(AccountMixin, PageElementMixin, ListCreateAPIVi
         return super(LiveEventListCreateAPIView, self).post(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-        serializer.save(element=self.element, status='scheduled')
+        serializer.save(element=self.element, status=LiveEvent.SCHEDULED)
 
 
 class LiveEventRetrieveUpdateDestroyAPIView(PageElementMixin, RetrieveUpdateDestroyAPIView):
@@ -471,6 +471,6 @@ class LiveEventRetrieveUpdateDestroyAPIView(PageElementMixin, RetrieveUpdateDest
 
     def delete(self, request, *args, **kwargs):
         live_event = self.get_object()
-        live_event.status = 'CANCELLED'
+        live_event.status = LiveEvent.CANCELLED
         live_event.save()
         return api_response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/pages/helpers.py
+++ b/pages/helpers.py
@@ -73,7 +73,6 @@ def set_extra(obj, attr_name, attr_value):
         # is to set it to some value.
         obj.extra = {}
     obj.extra.update({attr_name: attr_value})
-    obj.extra = json.dumps(obj.extra)
     return prev_val
 
 

--- a/pages/helpers.py
+++ b/pages/helpers.py
@@ -63,6 +63,20 @@ def get_extra(obj, attr_name, default=None):
         extra = obj.get('extra')
     return extra.get(attr_name, default) if extra else default
 
+
+def set_extra(obj, attr_name, attr_value):
+    prev_val = get_extra(obj, attr_name)
+
+    if not obj.extra:
+        # In case we have a None type or empty string, initialize
+        # extra as a dict because if we're using this method the intention
+        # is to set it to some value.
+        obj.extra = {}
+    obj.extra.update({attr_name: attr_value})
+    obj.extra = json.dumps(obj.extra)
+    return prev_val
+
+
 def update_context_urls(context, urls):
     if 'urls' in context:
         for key, val in six.iteritems(urls):

--- a/pages/mixins.py
+++ b/pages/mixins.py
@@ -330,7 +330,7 @@ class EnumeratedProgressMixin(SequenceProgressMixin):
                 sequence=self.sequence,
                 rank=self.rank)
             with transaction.atomic():
-                self._progress, _  = EnumeratedProgress.objects.get_or_create(
+                self._progress, _ = EnumeratedProgress.objects.get_or_create(
                     sequence_progress=self.sequence_progress,
                     step=step)
         return self._progress

--- a/pages/mixins.py
+++ b/pages/mixins.py
@@ -144,7 +144,7 @@ class PageElementMixin(object):
 
 class SequenceMixin(object):
     """
-    Returns an ``User`` from a URL.
+    Returns a ``Sequence`` from a URL.
     """
     sequence_url_kwarg = 'sequence'
 
@@ -315,11 +315,17 @@ class EnumeratedProgressMixin(SequenceProgressMixin):
     rank_url_kwarg = 'rank'
 
     @property
+    def rank(self):
+        if not hasattr(self, '_rank'):
+            self._rank = self.kwargs.get(self.rank_url_kwarg, 1)
+        return self._rank
+
+    @property
     def progress(self):
         if not hasattr(self, '_progress'):
             step = get_object_or_404(EnumeratedElements.objects.all(),
                 sequence=self.sequence,
-                rank=self.kwargs.get(self.rank_url_kwarg, 1))
+                rank=self.rank)
             with transaction.atomic():
                 self._progress, _  = EnumeratedProgress.objects.get_or_create(
                     sequence_progress=self.sequence_progress,

--- a/pages/models.py
+++ b/pages/models.py
@@ -394,8 +394,9 @@ class LiveEvent(models.Model):
     location = models.URLField(_("URL to the calendar event"), max_length=2083)
     max_attendees = models.IntegerField(default=0)
     status = models.CharField(
-        choices=(('active', 'Active'), ('cancelled', 'Cancelled'), 
-                 ('updated', 'Updated')), max_length=9)
+        max_length=9,
+        choices=(('scheduled', 'Scheduled'), ('cancelled', 'Cancelled')),
+        default='scheduled', help_text=_("Current status of the LiveEvent"))
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
 

--- a/pages/models.py
+++ b/pages/models.py
@@ -389,19 +389,21 @@ class LiveEvent(models.Model):
         help_text=_("Date/time the live event was created (in ISO format)"))
     scheduled_at = models.DateTimeField(
         help_text=_("Date/time the live event is scheduled (in ISO format)"))
-    index = models.PositiveSmallIntegerField(default=1,
+    rank = models.PositiveSmallIntegerField(default=1,
         help_text="Unique integer to denote the index of the LiveEvent")
     location = models.URLField(_("URL to the calendar event"), max_length=2083)
     max_attendees = models.IntegerField(default=0)
+    status = models.CharField(
+        choices=(('active', 'Active'), ('cancelled', 'Cancelled'), 
+                 ('updated', 'Updated')), max_length=9)
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
-    # Maybe we can add "status" to the extra and use it to filter
-    # live events for ones that are active or a new status field
+
     def __str__(self):
-        return "%s-live" % str(self.element)
+        return "%s-live-%s" % (str(self.element), str(self.rank))
     
     class Meta:
-        unique_together = ('element', 'index')
+        unique_together = ('element', 'rank')
 
 
 @python_2_unicode_compatible
@@ -514,9 +516,10 @@ class EnumeratedProgress(models.Model):
         default=datetime.timedelta,  # stored in microseconds
         help_text=_("Total recorded viewing time for the material"))
     last_ping_time = models.DateTimeField(
-        null=True,
-        blank=True,
+        null=True, blank=True,
         help_text=_("Timestamp of the last activity ping"))
+    extra = get_extra_field_class()(null=True, blank=True,
+        help_text=_("Extra meta data (can be stringify JSON)"))
 
     class Meta:
         unique_together = ('sequence_progress', 'step')

--- a/pages/models.py
+++ b/pages/models.py
@@ -396,6 +396,9 @@ class LiveEvent(models.Model):
 
     def __str__(self):
         return "%s-live" % str(self.element)
+    
+    class Meta:
+        unique_together = ('element', 'scheduled_at')
 
 
 @python_2_unicode_compatible
@@ -483,12 +486,12 @@ class SequenceProgress(models.Model):
             enumerated_elements = EnumeratedElements.objects.filter(
                 sequence=self.sequence).order_by('rank')
         user_enumerated_progress = EnumeratedProgress.objects.filter(
-            progress=self,
-            rank__in=enumerated_elements.values_list(
+            sequence_progress=self,
+            step__rank__in=enumerated_elements.values_list(
             'rank', flat=True))
         for element in enumerated_elements:
             if not user_enumerated_progress.filter(
-                    rank=element.rank,
+                    step__rank=element.rank,
                     viewing_duration__gte=element.min_viewing_duration
             ).exists():
                 return False

--- a/pages/models.py
+++ b/pages/models.py
@@ -383,9 +383,12 @@ class LiveEvent(models.Model):
     """
     A live webinar, onsite classroom, etc.
     """
+    CANCELLED = "Cancelled"
+    SCHEDULED = "Scheduled"
+
     EVENT_STATUS_CHOICES = (
-        ('SCHEDULED', 'Scheduled'),
-        ('CANCELLED', 'Cancelled')
+        (CANCELLED, 'Cancelled'),
+        (SCHEDULED, 'Scheduled')
     )
 
     element = models.ForeignKey(PageElement, on_delete=models.CASCADE,
@@ -400,7 +403,7 @@ class LiveEvent(models.Model):
     max_attendees = models.IntegerField(default=0)
     status = models.CharField(
         max_length=9,
-        choices=EVENT_STATUS_CHOICES, default='SCHEDULED',
+        choices=EVENT_STATUS_CHOICES, default=SCHEDULED,
         help_text=_("Current status of the LiveEvent"))
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))

--- a/pages/models.py
+++ b/pages/models.py
@@ -389,16 +389,19 @@ class LiveEvent(models.Model):
         help_text=_("Date/time the live event was created (in ISO format)"))
     scheduled_at = models.DateTimeField(
         help_text=_("Date/time the live event is scheduled (in ISO format)"))
+    index = models.PositiveSmallIntegerField(default=1,
+        help_text="Unique integer to denote the index of the LiveEvent")
     location = models.URLField(_("URL to the calendar event"), max_length=2083)
     max_attendees = models.IntegerField(default=0)
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
-
+    # Maybe we can add "status" to the extra and use it to filter
+    # live events for ones that are active or a new status field
     def __str__(self):
         return "%s-live" % str(self.element)
     
     class Meta:
-        unique_together = ('element', 'scheduled_at')
+        unique_together = ('element', 'index')
 
 
 @python_2_unicode_compatible

--- a/pages/models.py
+++ b/pages/models.py
@@ -383,6 +383,11 @@ class LiveEvent(models.Model):
     """
     A live webinar, onsite classroom, etc.
     """
+    EVENT_STATUS_CHOICES = (
+        ('SCHEDULED', 'Scheduled'),
+        ('CANCELLED', 'Cancelled')
+    )
+
     element = models.ForeignKey(PageElement, on_delete=models.CASCADE,
         related_name='events')
     created_at = models.DateTimeField(editable=False, auto_now_add=True,
@@ -395,8 +400,8 @@ class LiveEvent(models.Model):
     max_attendees = models.IntegerField(default=0)
     status = models.CharField(
         max_length=9,
-        choices=(('scheduled', 'Scheduled'), ('cancelled', 'Cancelled')),
-        default='scheduled', help_text=_("Current status of the LiveEvent"))
+        choices=EVENT_STATUS_CHOICES, default='SCHEDULED',
+        help_text=_("Current status of the LiveEvent"))
     extra = get_extra_field_class()(null=True, blank=True,
         help_text=_("Extra meta data (can be stringify JSON)"))
 

--- a/pages/models.py
+++ b/pages/models.py
@@ -457,7 +457,7 @@ class EnumeratedElements(models.Model):
     One element in a sequence
     """
     sequence = models.ForeignKey(Sequence, on_delete=models.CASCADE,
-                                 related_name='sequence_enumerated_elements')
+        related_name='sequence_enumerated_elements')
     content = models.ForeignKey(PageElement, on_delete=models.CASCADE)
     rank = models.IntegerField(
         help_text=_("Used to order elements when presenting a sequence"))

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -394,12 +394,13 @@ class LiveEventSerializer(serializers.ModelSerializer):
         fields = ('scheduled_at', 'rank', 'location', 'max_attendees', 'status')
         read_only_fields = ('status',)
 
+
 class LiveEventAttendeesSerializer(EnumeratedProgressSerializer):
     user = serializers.SerializerMethodField(
         help_text=_("Username of the attendee"))
 
     class Meta(EnumeratedProgressSerializer.Meta):
-        fields = EnumeratedProgressSerializer.Meta.fields + ('user',)
+        fields = ('user', 'content', 'viewing_duration', 'min_viewing_duration')
         read_only_fields = EnumeratedProgressSerializer.Meta.read_only_fields + ('user',)
 
     def get_user(self, obj):

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -378,28 +378,21 @@ class EnumeratedProgressSerializer(EnumeratedElementSerializer):
             'certificate', 'viewing_duration',)
 
 
-class AttendanceInputSerializer(serializers.Serializer):
-    """
-    Serializer to validate input to mark users' attendance
-    to a LiveEvent(LiveEventAttendanceAPIView)
-    """
-    scheduled_at = serializers.DateTimeField(
-        help_text='Date/time the live event is scheduled')
-
-
 class LiveEventSerializer(serializers.ModelSerializer):
     element = serializers.SlugRelatedField(
         queryset=PageElement.objects.all(),
         slug_field="slug",
-        help_text=_("LiveEvent the enumerated element is for"),
+        help_text=_('LiveEvent the enumerated element is for'),
         required=True)
     scheduled_at = serializers.DateTimeField(
-        help_text='Date/time the live event is scheduled')
+        help_text=_('Date/time the live event is scheduled'))
+    index = serializers.IntegerField(
+        help_text=_('Unique integer to denote the index of the LiveEvent'))
     location = serializers.URLField(
-        help_text='URL to the live event')
+        help_text=_('URL to the live event'))
     max_attendees = serializers.IntegerField(default=0,
-        help_text='Max attendees for the LiveEvent')
+        help_text=_('Max attendees for the LiveEvent'))
 
     class Meta:
         model = LiveEvent
-        fields = ('element', 'scheduled_at', 'location', 'max_attendees')
+        fields = ('element', 'scheduled_at', 'index', 'location', 'max_attendees')

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -379,20 +379,28 @@ class EnumeratedProgressSerializer(EnumeratedElementSerializer):
 
 
 class LiveEventSerializer(serializers.ModelSerializer):
-    element = serializers.SlugRelatedField(
-        queryset=PageElement.objects.all(),
-        slug_field="slug",
-        help_text=_('LiveEvent the enumerated element is for'),
-        required=True)
     scheduled_at = serializers.DateTimeField(
         help_text=_('Date/time the live event is scheduled'))
-    index = serializers.IntegerField(
+    rank = serializers.IntegerField(
         help_text=_('Unique integer to denote the index of the LiveEvent'))
     location = serializers.URLField(
         help_text=_('URL to the live event'))
     max_attendees = serializers.IntegerField(default=0,
         help_text=_('Max attendees for the LiveEvent'))
+    status = serializers.CharField(read_only=True)
 
     class Meta:
         model = LiveEvent
-        fields = ('element', 'scheduled_at', 'index', 'location', 'max_attendees')
+        fields = ('scheduled_at', 'rank', 'location', 'max_attendees', 'status')
+        read_only_fields = ('status',)
+
+class LiveEventAttendeesSerializer(EnumeratedProgressSerializer):
+    user = serializers.SerializerMethodField(
+        help_text=_("Username of the attendee"))
+
+    class Meta(EnumeratedProgressSerializer.Meta):
+        fields = EnumeratedProgressSerializer.Meta.fields + ('user',)
+        read_only_fields = EnumeratedProgressSerializer.Meta.read_only_fields + ('user',)
+
+    def get_user(self, obj):
+        return obj.sequence_progress.user.username

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -387,7 +387,8 @@ class LiveEventSerializer(serializers.ModelSerializer):
         help_text=_('URL to the live event'))
     max_attendees = serializers.IntegerField(default=0,
         help_text=_('Max attendees for the LiveEvent'))
-    status = serializers.CharField(read_only=True)
+    status = serializers.CharField(
+        help_text=_("Current status of the LiveEvent"))
 
     class Meta:
         model = LiveEvent

--- a/pages/serializers.py
+++ b/pages/serializers.py
@@ -32,7 +32,7 @@ from rest_framework import serializers
 from . import settings
 from .compat import gettext_lazy as _, is_authenticated
 from .models import (Comment, Follow, PageElement, Vote, Sequence,
-    EnumeratedElements)
+    EnumeratedElements, LiveEvent)
 
 #pylint: disable=abstract-method
 
@@ -383,3 +383,23 @@ class AttendanceInputSerializer(serializers.Serializer):
     Serializer to validate input to mark users' attendance
     to a LiveEvent(LiveEventAttendanceAPIView)
     """
+    scheduled_at = serializers.DateTimeField(
+        help_text='Date/time the live event is scheduled')
+
+
+class LiveEventSerializer(serializers.ModelSerializer):
+    element = serializers.SlugRelatedField(
+        queryset=PageElement.objects.all(),
+        slug_field="slug",
+        help_text=_("LiveEvent the enumerated element is for"),
+        required=True)
+    scheduled_at = serializers.DateTimeField(
+        help_text='Date/time the live event is scheduled')
+    location = serializers.URLField(
+        help_text='URL to the live event')
+    max_attendees = serializers.IntegerField(default=0,
+        help_text='Max attendees for the LiveEvent')
+
+    class Meta:
+        model = LiveEvent
+        fields = ('element', 'scheduled_at', 'location', 'max_attendees')

--- a/pages/templates/pages/app/sequences/pageelement.html
+++ b/pages/templates/pages/app/sequences/pageelement.html
@@ -15,7 +15,20 @@
 
 
     {% if element.is_live_event %}
-        <p>Live Event URL: <a href="{{ urls.live_event_location }}">{{ element.content.events.first.location }}</a></p>
+    <table>
+        <tr>
+            <th>Event URL</th>
+            <th>Event Date</th>
+            <th>Event Max Attendees</th>
+        </tr>
+    {% for event in events %}
+        <tr>
+            <td><a href="{{ event.location }}">{{ event.location }}</a></td>
+            <td>{{ event.scheduled_at }}</td>
+            <td>{{ event.max_attendees }}</td>
+        </tr>
+    {% endfor %}
+    </table>
 
     {% elif element.is_certificate %}
         <p>This is a certificate. <a href="{{ urls.certificate_download }}">Download Certificate</a></p>

--- a/pages/urls/api/editables.py
+++ b/pages/urls/api/editables.py
@@ -34,16 +34,19 @@ from ...api.relationship import (PageElementAliasAPIView,
 from ...api.sequences import (SequenceListCreateAPIView,
     SequenceRetrieveUpdateDestroyAPIView,
     RemoveElementFromSequenceAPIView, AddElementToSequenceAPIView,
-    LiveEventCreateAPIView, LiveEventDeleteAPIView)
+    LiveEventListCreatePIView, LiveEventDeleteAPIView)
 
 
 urlpatterns = [
-    path('elements/live-event/<slug:slug>', 
+    # Move these live event URLs with PageElement URLs
+    # They also have the account in the URL, not necessary?
+    path('elements/<slug:slug>/live-events/<int:index>', 
          LiveEventDeleteAPIView.as_view(),
-         name='liveeventdel'),
-    path('elements/live-event', 
-         LiveEventCreateAPIView.as_view(),
-         name='liveeventadd'),
+         name='api_live_event_destroy'),
+    path('elements/<slug:slug>/live-events',
+         LiveEventListCreatePIView.as_view(),
+         name='api_live_event_list_create'),
+
     path(r'sequences/<slug:sequence>/elements/<int:rank>',
          RemoveElementFromSequenceAPIView.as_view(),
          name='api_remove_element_from_sequence'),

--- a/pages/urls/api/editables.py
+++ b/pages/urls/api/editables.py
@@ -34,17 +34,17 @@ from ...api.relationship import (PageElementAliasAPIView,
 from ...api.sequences import (SequenceListCreateAPIView,
     SequenceRetrieveUpdateDestroyAPIView,
     RemoveElementFromSequenceAPIView, AddElementToSequenceAPIView,
-    LiveEventListCreatePIView, LiveEventDeleteAPIView)
+    LiveEventListCreateAPIView, LiveEventRetrieveUpdateDestroyAPIView)
 
 
 urlpatterns = [
     # Move these live event URLs with PageElement URLs
     # They also have the account in the URL, not necessary?
-    path('elements/<slug:slug>/live-events/<int:index>', 
-         LiveEventDeleteAPIView.as_view(),
+    path('<slug>/live-events/<int:rank>',
+         LiveEventRetrieveUpdateDestroyAPIView.as_view(),
          name='api_live_event_destroy'),
-    path('elements/<slug:slug>/live-events',
-         LiveEventListCreatePIView.as_view(),
+    path('<slug>/live-events',
+         LiveEventListCreateAPIView.as_view(),
          name='api_live_event_list_create'),
 
     path(r'sequences/<slug:sequence>/elements/<int:rank>',

--- a/pages/urls/api/editables.py
+++ b/pages/urls/api/editables.py
@@ -39,7 +39,8 @@ from ...api.sequences import (SequenceListCreateAPIView,
 
 urlpatterns = [
     # Move these live event URLs with PageElement URLs
-    # They also have the account in the URL, not necessary?
+    # They also have the account in the URL, how to check
+    # access?
     path('<slug>/live-events/<int:rank>',
          LiveEventRetrieveUpdateDestroyAPIView.as_view(),
          name='api_live_event_destroy'),

--- a/pages/urls/api/editables.py
+++ b/pages/urls/api/editables.py
@@ -33,10 +33,17 @@ from ...api.relationship import (PageElementAliasAPIView,
     PageElementMirrorAPIView, PageElementMoveAPIView)
 from ...api.sequences import (SequenceListCreateAPIView,
     SequenceRetrieveUpdateDestroyAPIView,
-    RemoveElementFromSequenceAPIView, AddElementToSequenceAPIView)
+    RemoveElementFromSequenceAPIView, AddElementToSequenceAPIView,
+    LiveEventCreateAPIView, LiveEventDeleteAPIView)
 
 
 urlpatterns = [
+    path('elements/live-event/<slug:slug>', 
+         LiveEventDeleteAPIView.as_view(),
+         name='liveeventdel'),
+    path('elements/live-event', 
+         LiveEventCreateAPIView.as_view(),
+         name='liveeventadd'),
     path(r'sequences/<slug:sequence>/elements/<int:rank>',
          RemoveElementFromSequenceAPIView.as_view(),
          name='api_remove_element_from_sequence'),

--- a/pages/urls/api/sequences.py
+++ b/pages/urls/api/sequences.py
@@ -32,7 +32,7 @@ from ...compat import path
 
 
 urlpatterns = [
-    path('<slug:sequence>/<int:rank>/<slug:user>',
+    path('<slug:sequence>/<slug:user>/<int:rank>/',
          LiveEventAttendanceAPIView.as_view(),
          name='api_mark_attendance'),
     path('<slug:sequence>/<slug:user>',

--- a/pages/urls/api/sequences.py
+++ b/pages/urls/api/sequences.py
@@ -27,14 +27,17 @@ API URLs for sequence objects
 """
 
 from ...api.progress import (EnumeratedProgressResetAPIView,
-    LiveEventAttendanceAPIView)
+    LiveEventAttendanceAPIView, LiveEventAttendeesAPIView)
 from ...compat import path
 
 
 urlpatterns = [
-    path('<slug:sequence>/<slug:user>/<int:rank>/',
+    path('<slug:sequence>/<int:rank>/<int:event_rank>/attendees/<slug:user>',
          LiveEventAttendanceAPIView.as_view(),
          name='api_mark_attendance'),
+     path('<slug:sequence>/<int:rank>/<int:event_rank>/attendees',
+         LiveEventAttendeesAPIView.as_view(),
+         name='api_live_event_attendees'),
     path('<slug:sequence>/<slug:user>',
          EnumeratedProgressResetAPIView.as_view(),
          name='api_progress_reset'),

--- a/pages/views/sequences.py
+++ b/pages/views/sequences.py
@@ -43,7 +43,7 @@ class SequenceProgressView(SequenceProgressMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(SequenceProgressView, self).get_context_data(**kwargs)
 
-        queryset = self.get_queryset()
+        queryset = self.get_queryset().order_by('rank')
         decorated_queryset = self.decorate_queryset(queryset)
 
         context.update({
@@ -129,9 +129,9 @@ class SequencePageElementView(EnumeratedProgressMixin, TemplateView):
         }
 
         if hasattr(element, 'is_live_event') and element.is_live_event:
-            event = element.content.events.first()
-            if event:
-                context_urls['live_event_location'] = event.location
+            events = self.live_events
+            if events:
+                context.update({'events': events})
 
         if hasattr(element, 'is_certificate') and element.is_certificate:
             certificate = element.sequence.get_certificate

--- a/pages/views/sequences.py
+++ b/pages/views/sequences.py
@@ -71,7 +71,7 @@ class SequenceProgressView(SequenceProgressMixin, TemplateView):
 class SequencePageElementView(EnumeratedProgressMixin, TemplateView):
 
     template_name = 'pages/app/sequences/pageelement.html'
-    # is_live_event and is_certificate flags not being added
+
     def get_context_data(self, **kwargs):
         #pylint:disable=too-many-locals
         context = super(SequencePageElementView,

--- a/testsite/fixtures/default-db.json
+++ b/testsite/fixtures/default-db.json
@@ -234,11 +234,24 @@
       "element": 107,
       "created_at": "2023-03-15T10:00:00Z",
       "scheduled_at": "2023-04-10T15:00:00Z",
+      "index": 1,
       "location": "http://127.0.0.1:8000/webinar/sustainability",
       "max_attendees": 100,
       "extra": "{}"
     },
     "model": "pages.LiveEvent", "pk": 200
+},
+{
+  "fields": {
+    "element": 107,
+    "created_at": "2023-03-15T10:00:00Z",
+    "scheduled_at": "2023-04-10T15:00:00Z",
+    "index": 2,
+    "location": "http://127.0.0.1:8000/webinar/sustainability",
+    "max_attendees": 10,
+    "extra": "{}"
+  },
+  "model": "pages.LiveEvent", "pk": 201
 },
 {
   "fields": {

--- a/testsite/fixtures/default-db.json
+++ b/testsite/fixtures/default-db.json
@@ -234,7 +234,7 @@
       "element": 107,
       "created_at": "2023-03-15T10:00:00Z",
       "scheduled_at": "2023-04-10T15:00:00Z",
-      "index": 1,
+      "rank": 1,
       "location": "http://127.0.0.1:8000/webinar/sustainability",
       "max_attendees": 100,
       "extra": "{}"
@@ -246,7 +246,7 @@
     "element": 107,
     "created_at": "2023-03-15T10:00:00Z",
     "scheduled_at": "2023-04-10T15:00:00Z",
-    "index": 2,
+    "rank": 2,
     "location": "http://127.0.0.1:8000/webinar/sustainability",
     "max_attendees": 10,
     "extra": "{}"

--- a/testsite/fixtures/default-db.json
+++ b/testsite/fixtures/default-db.json
@@ -231,7 +231,7 @@
 },
 {
     "fields": {
-      "element": 100,
+      "element": 107,
       "created_at": "2023-03-15T10:00:00Z",
       "scheduled_at": "2023-04-10T15:00:00Z",
       "location": "http://127.0.0.1:8000/webinar/sustainability",


### PR DESCRIPTION
- Early versions of API endpoints/URLs to add and delete LiveEvents.
- Gets LiveEvent objects using their scheduled_at time, for adding/deleting as well as marking attendance.
- Updates Mixin to add a rank property to help correctly add attributes to LiveEvent objects.

Issues:
 - On the URL: `http://127.0.0.1:8000/sequences/steve/seq-cert-live-event/1/` if a user is not logged in, they are able to make POST requests and the timer updates, but if logged in as either steve or a superuser it returns `djaodjin-pages-vue.js:581 Error sending ping: Forbidden` Haven't investigated yet.