### PR TITLE
[WIP] Add support for Django 5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ vendor-assets-prerequisites: $(ASSETS_DIR)/vendor/vue.js
 
 $(ASSETS_DIR)/vendor/vue.js: $(srcDir)/testsite/package.json
 	$(installFiles) $^ $(installTop)
-	$(NPM) install --loglevel verbose --cache $(installTop)/.npm --tmp $(installTop)/tmp --prefix $(installTop)
+	$(NPM) install --loglevel verbose --cache $(installTop)/.npm --prefix $(installTop)
 	$(installDirs) $(ASSETS_DIR)/vendor $(ASSETS_DIR)/fonts
 	$(installFiles) $(installTop)/node_modules/dropzone/dist/dropzone.css $(ASSETS_DIR)/vendor
 	$(installFiles) $(installTop)/node_modules/dropzone/dist/dropzone.js $(ASSETS_DIR)/vendor

--- a/pages/api/assets.py
+++ b/pages/api/assets.py
@@ -27,7 +27,7 @@ import hashlib, logging, os
 
 import boto3
 from deployutils.helpers import datetime_or_now
-from django.core.files.storage import get_storage_class, FileSystemStorage
+from django.core.files.storage import FileSystemStorage
 from django.http import HttpResponseRedirect
 from django.utils.module_loading import import_string
 from rest_framework import parsers, status
@@ -37,7 +37,7 @@ from rest_framework.response import Response as HttpResponse
 
 from .. import settings
 from ..compat import (NoReverseMatch, force_str, gettext_lazy as _, reverse,
-    urljoin, urlparse)
+    urljoin, urlparse, get_storage_class)
 from ..mixins import AccountMixin
 from ..serializers import AssetSerializer
 

--- a/pages/compat.py
+++ b/pages/compat.py
@@ -196,3 +196,23 @@ def is_authenticated(request):
     if callable(request.user.is_authenticated):
         return request.user.is_authenticated()
     return request.user.is_authenticated
+
+
+try:
+    from django.core.files.storage import storages # Added in Django 4.2
+    def get_storage_class():
+        """Returns a class object of of the default storage backend.
+
+        Simplified re-implementation of the old upstream version. Takes no
+        arguments, since we only ever use it to get the default backend.
+        Whenever we drop support for Django 3.2, we should rewrite references
+        to this function to use `django.core.files.storage.storages' instead
+        (not a drop-in replacement).
+
+        See:
+        https://docs.djangoproject.com/en/4.2/_modules/django/core/files/storage/
+
+        """
+        return import_string(storages.backends['default']['BACKEND'])
+except ImportError:
+    from django.core.files.storage import get_storage_class # Removed in Django 5.0

--- a/testsite/requirements.txt
+++ b/testsite/requirements.txt
@@ -1,9 +1,20 @@
 # djaodjin-pages
 bleach==6.0.0
-Django==3.2.25
-djangorestframework==3.14.0         #  3.12.4 does not support Django4.2
-djaodjin-deployutils==0.11.0
-djaodjin-extended-templates==0.4.6
+Django==3.2.25 ; python_version < "3.9"
+Django==4.2.19 ; python_version >= "3.9" and python_version < "3.12"
+Django==5.1.6 ; python_version >= "3.12"
+djangorestframework==3.14.0 ; python_version < "3.9"  # 3.12.4 does not support
+                                                      # Django4.2
+djangorestframework==3.15.2 ; python_version >= "3.9" # Breaking changes in
+                                                      # 3.15.0 and 3.15.1 were
+                                                      # reverted in 3.15.2.
+                                                      # Requires Django >=4.2
+                                                      # and Python >=3.8. See
+                                                      # release notes for
+                                                      # details:
+                                                      # https://github.com/encode/django-rest-framework/releases
+djaodjin-deployutils==0.12.0
+djaodjin-extended-templates==0.4.8
 mammoth==1.6.0
 markdownify==0.11.6
 Markdown==3.4.1
@@ -12,9 +23,8 @@ requests==2.31.0
 
 # testsite-only
 coverage==6.3.2
-django-debug-toolbar==3.8.1       # 3.4.0 requires Django>=3.2
-                                  # 3.2.4 fails with SQLPanel is not scriptable
-                                  # 2.2.1 is the last version for Django2.2
-django-extensions==3.2.1
-gunicorn==20.1.0
+django-debug-toolbar==5.0.1 ; python_version >= "3.9"
+django-debug-toolbar==3.8.1 ; python_version < "3.9"
+django-extensions==3.2.3
+gunicorn==23.0.0
 whitenoise==5.1.0


### PR DESCRIPTION
4.2 support is done. 5.1 support still has some bugs, namely, the new filter-related ValueError we encountered in djaodjin-survey.